### PR TITLE
Allow findConnections end_type to be on any dest parent

### DIFF
--- a/scripts/Targets.pm
+++ b/scripts/Targets.pm
@@ -955,6 +955,29 @@ sub findConnections
                 if ($type eq "NA") {
                     $type = $dest_class;
                 }
+
+                if ($end_type ne "") {
+                    #Look for an end_type match on any ancestor, as
+                    #connections may have a destination unit with a hierarchy
+                    #like unit->pingroup->muxgroup->chip where the chip has
+                    #the interesting type.
+                    while ($type ne $end_type) {
+
+                        $dest_parent = $self->getTargetParent($dest_parent);
+                        if ($dest_parent eq "") {
+                            last;
+                        }
+
+                        $type = $self->getMrwType($dest_parent);
+                        if ($type eq "NA") {
+                            $type = $self->getType($dest_parent);
+                        }
+                        if ($type eq "NA") {
+                            $type = $self->getAttribute($dest_parent, "CLASS");
+                        }
+                    }
+                }
+
                 if ($type eq $end_type || $end_type eq "")
                 {
                     $connections{CONN}[$num]{SOURCE}=$child;


### PR DESCRIPTION
Allow the end_type argument of findConnections to match
on the type of any parent ancestor of the dest unit
to allow for units that are buried in a deeper hierarchy
than just unit->chip (such as unit->unit->unit->chip).

Signed-off-by: Matt Spinler <spinler@us.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/serverwiz/30)
<!-- Reviewable:end -->
