### PR TITLE
Targets.pm: Don't fail if BUS_TYPE is missing

### DIFF
--- a/scripts/Targets.pm
+++ b/scripts/Targets.pm
@@ -938,7 +938,12 @@ sub findConnections
 
     foreach my $child ($self->getAllTargetChildren($target))
     {
-        my $child_bus_type = $self->getBusType($child);
+        my $child_bus_type = "";
+        if (!$self->isBadAttribute($child, "BUS_TYPE"))
+        {
+            $child_bus_type = $self->getBusType($child);
+        }
+
         if ($child_bus_type eq $bus_type)
         {
             for (my $i = 0; $i < $self->getNumConnections($child); $i++)


### PR DESCRIPTION
In findConnections, don't die if a target is missing the BUS_TYPE attribute.

There are many targets in the current witherspoon.xml that are missing this attribute, and cause fails looking for connections completely unrelated to those targets.

Signed-off-by: Matt Spinler <spinler@us.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/serverwiz/32)
<!-- Reviewable:end -->
