### PR TITLE
Add ability to export cards

### DIFF
--- a/src/com/ibm/ServerWizard2/controller/TargetWizardController.java
+++ b/src/com/ibm/ServerWizard2/controller/TargetWizardController.java
@@ -128,6 +128,7 @@ public class TargetWizardController {
 			// target instance found of this model type
 			targetInstance = new Target(instanceCheck);
 			targetInstance.copyChildren(instanceCheck);
+			targetInstance.copyBusses(instanceCheck);
 		} else {
 			targetInstance = new Target(targetModel);
 		}
@@ -156,6 +157,21 @@ public class TargetWizardController {
 			newTarget = null;
 		}
 		return newTarget;
+	}
+	
+	public void exportAsPart(Target target, String fileName, Boolean defaultAttributes) {
+		try {
+			String tmpFilename = fileName + ".tmp";
+			model.writeXML(tmpFilename, target, defaultAttributes);
+			File from = new File(tmpFilename);
+			File to = new File(fileName);
+			Files.copy(from.toPath(), to.toPath(),
+					StandardCopyOption.REPLACE_EXISTING);
+			Files.delete(from.toPath());
+			ServerWizard2.LOGGER.info(fileName + " Saved");
+		} catch (Exception e) {
+			ServerwizMessageDialog.openError(null, "Export Part Error", e.getMessage());
+		}
 	}
 
 	public void deleteConnection(Target target, Target busTarget,

--- a/src/com/ibm/ServerWizard2/model/Connection.java
+++ b/src/com/ibm/ServerWizard2/model/Connection.java
@@ -23,6 +23,21 @@ public class Connection {
 		}
 		return source.getName()+seperator+dest.getName();
 	}
+	public Connection() {
+		// TODO Auto-generated constructor stub
+	}
+	public Connection(Connection other) {
+		id = other.id;
+		busType = other.busType;
+		source = new ConnectionEndpoint();
+		dest = new ConnectionEndpoint();
+		source.setTargetName(other.source.getTargetName());
+		source.setPath(other.source.getPath());
+		dest.setTargetName(other.dest.getTargetName());
+		dest.setPath(other.dest.getPath());
+		cabled = other.cabled;
+		busTarget = new Target(other.busTarget);
+	}
 	public void writeInstanceXML(Writer out) throws Exception {
 		out.write("\t<bus>\n");
 		out.write("\t\t<bus_id>"+getName()+"</bus_id>\n");

--- a/src/com/ibm/ServerWizard2/model/SystemModel.java
+++ b/src/com/ibm/ServerWizard2/model/SystemModel.java
@@ -615,7 +615,7 @@ public class SystemModel {
 		HashMap<String, Boolean> targetWritten = new HashMap<String, Boolean>();
 		for (Target target : targetList) {
 			if (partsMode) {
-				target.writeTargetXML(out, targetLookup, targetWritten);
+				target.writeTargetXML(out, targetLookup, targetWritten, false, false, null);
 			} else {
 				target.writeInstanceXML(out, targetLookup, targetWritten);
 			}
@@ -624,7 +624,25 @@ public class SystemModel {
 		out.write("</"+topTag+">\n");
 		out.close();
 	}
-
+	
+	/*
+	 * Write XML to a parts file (only the supplied target and it's children)
+	 */
+	public void writeXML(String filename, Target topTarget, Boolean defaultAttributes) throws Exception {
+		Writer out = new BufferedWriter(new FileWriter(filename));
+		
+		out.write("<partInstance>\n");
+		out.write("<version>"+ServerWizard2.getVersionString()+"</version>\n");
+		out.write("<targetInstances>\n");
+		HashMap<String, Boolean> targetWritten = new HashMap<String, Boolean>();
+	    topTarget.writeTargetXML(out, targetLookup, targetWritten, true, true,
+	    		defaultAttributes ? attributes : null);
+		out.write("</targetInstances>\n");
+		out.write("</partInstance>\n");
+		out.close();		
+	}
+	
+	
 	/*
 	 * Add a target instance to the model
 	 */

--- a/src/com/ibm/ServerWizard2/view/MainDialog.java
+++ b/src/com/ibm/ServerWizard2/view/MainDialog.java
@@ -75,6 +75,7 @@ public class MainDialog extends Dialog {
 	// Buttons
 	private Button btnAddTarget;
 	private Button btnCopyInstance;
+	private Button btnExportPart;
 	private Button btnDefaults;
 	private Button btnDeleteTarget;
 	private Button btnSave;
@@ -287,6 +288,12 @@ public class MainDialog extends Dialog {
 		btnCopyInstance.setFont(SWTResourceManager.getFont("Arial", 9, SWT.NORMAL));
 		btnCopyInstance.setEnabled(false);
 
+		btnExportPart = new Button(compositeInstance, SWT.NONE);
+		btnExportPart.setLayoutData(new GridData(SWT.CENTER, SWT.CENTER, true, false, 1, 1));
+		btnExportPart.setText("Export Part");
+		btnExportPart.setFont(SWTResourceManager.getFont("Arial", 9, SWT.NORMAL));
+		btnExportPart.setEnabled(false);
+		
 		btnDefaults = new Button(compositeInstance, SWT.NONE);
 		btnDefaults.setLayoutData(new GridData(SWT.CENTER, SWT.CENTER, true, false, 1, 1));
 		btnDefaults.setText("Restore Defaults");
@@ -714,6 +721,7 @@ public class MainDialog extends Dialog {
 			btnAddTarget.setEnabled(false);
 			btnDeleteTarget.setEnabled(false);
 			btnCopyInstance.setEnabled(false);
+			btnExportPart.setEnabled(false);
 			btnDefaults.setEnabled(false);
 			updateChildCombo(null);
 			return;
@@ -742,6 +750,11 @@ public class MainDialog extends Dialog {
 			btnCopyInstance.setEnabled(true);
 		} else {
 			btnCopyInstance.setEnabled(false);
+		}
+		if (targetInstance.isCard()) {
+			btnExportPart.setEnabled(true);
+		} else {
+			btnExportPart.setEnabled(false);
 		}
 		btnDefaults.setEnabled(true);
 	}
@@ -1211,6 +1224,30 @@ public class MainDialog extends Dialog {
 				setDirtyState(true);
 			}
 		});
+		
+		btnExportPart.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent arg0) {
+				TreeItem selectedItem = tree.getSelection()[0];
+				if (selectedItem == null) {
+					return;
+				}
+				Target target = (Target) selectedItem.getData();
+				Button b = (Button) arg0.getSource();
+				FileDialog fdlg = new FileDialog(b.getShell(), SWT.SAVE);
+				String ext[] = { "*.xml" };
+				fdlg.setFilterExtensions(ext);
+				fdlg.setOverwrite(true);
+				String filename = fdlg.open();
+				if (filename == null) {
+					return;
+				}
+				Boolean defaultAttrs =
+						MessageDialog.openQuestion(null, "Default Attributes", "Would you like to default all attributes of the exported part?");
+				controller.exportAsPart(target, filename, defaultAttrs);
+			}
+		});
+		
 		btnDefaults.addSelectionListener(new SelectionAdapter() {
 			@Override
 			public void widgetSelected(SelectionEvent arg0) {


### PR DESCRIPTION
This commit adds the ability to export parts (cards)
out of an already loaded system XML. A part can be exported
by selecting the card in the target instance tree view and
selecting the "Export Part" button. Any busses internal to
the card (or any sub-cards) will be retained in the exported
part XML.

When exporting, the user can choose whether to retain
attribute values on the part or to default all of them.

The exported part XML is just like any other part XML.
It can be placed in the parts directory and following a
Serverwiz tool restart, will be picked up and be available
in the target dropdown for adding to a system XML.